### PR TITLE
Add udev rule to tty symlink

### DIFF
--- a/99-arduino.rules
+++ b/99-arduino.rules
@@ -1,0 +1,2 @@
+#New USB device found, idVendor=2341, idProduct=0042, bcdDevice= 0.01
+SUBSYSTEM=="tty", ATTRS{idVendor}=="2341", ATTRS{idProduct}=="0042", SYMLINK+="ventilator"

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,10 @@ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add -
 add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
 apt-get update
 apt-get install docker-ce docker-ce-cli containerd.io python3 python3-pip
-pip3 install pymongo pyserial websockets 
+pip3 install pymongo pyserial websockets
+
+# Make udev create /dev/ventilator symlink when an Arduino Mega is plugged in.
+install --user=root --group=root ./99-arduino.rules /etc/udev/rules.d
+udevadm control --reload
 
 echo "Run 'docker-compose up' to start the server"


### PR DESCRIPTION
If an Arduino Mega is plugged in to the machine a symlink `/dev/ventilator` will
be created. This removes the issue of ttyACM{0...n} numbering in the python code.

Signed-off-by: Frank Vanbever <frank.vanbever@gmail.com>